### PR TITLE
Rename HelloWorldConfig

### DIFF
--- a/src/deploy/environments/index.ts
+++ b/src/deploy/environments/index.ts
@@ -2,7 +2,7 @@ import { EnvironmentConfig, RouterConfig } from '@abacus-network/deploy';
 import { TemplateNetworks } from '../../deploy/networks';
 import { environment as testEnvironment } from './test';
 
-export type HelloWorldConfig = EnvironmentConfig<TemplateNetworks> & {
+export type HelloWorldEnvironmentConfig = EnvironmentConfig<TemplateNetworks> & {
   config: RouterConfig;
 };
 

--- a/src/deploy/environments/index.ts
+++ b/src/deploy/environments/index.ts
@@ -2,9 +2,10 @@ import { EnvironmentConfig, RouterConfig } from '@abacus-network/deploy';
 import { TemplateNetworks } from '../../deploy/networks';
 import { environment as testEnvironment } from './test';
 
-export type HelloWorldEnvironmentConfig = EnvironmentConfig<TemplateNetworks> & {
-  config: RouterConfig;
-};
+export type HelloWorldEnvironmentConfig =
+  EnvironmentConfig<TemplateNetworks> & {
+    config: RouterConfig;
+  };
 
 export const environments = {
   test: testEnvironment,

--- a/src/deploy/environments/test.ts
+++ b/src/deploy/environments/test.ts
@@ -1,7 +1,7 @@
 import { configs } from '../networks';
-import { HelloWorldConfig } from './index';
+import { HelloWorldEnvironmentConfig } from './index';
 
-export const environment: HelloWorldConfig = {
+export const environment: HelloWorldEnvironmentConfig = {
   ...configs,
   config: {},
 };

--- a/src/deploy/scripts/utils.ts
+++ b/src/deploy/scripts/utils.ts
@@ -1,7 +1,7 @@
-import { environments, HelloWorldConfig } from '../environments';
+import { environments, HelloWorldEnvironmentConfig } from '../environments';
 
 export async function getEnvironmentConfig(
   environment: keyof typeof environments,
-): Promise<HelloWorldConfig> {
+): Promise<HelloWorldEnvironmentConfig> {
   return environments[environment];
 }

--- a/test/HelloWorldDeploy.ts
+++ b/test/HelloWorldDeploy.ts
@@ -4,14 +4,13 @@ import { TestAbacusDeploy, TestRouterDeploy } from '@abacus-network/hardhat';
 
 import { HelloWorld__factory, HelloWorld } from '../src/types';
 
-// HelloWorld has no configurable variables.
-export type HelloWorldConfig = {
+type HelloWorldTestConfig = {
   signer: SignerWithAddress;
 };
 
 export class HelloWorldDeploy extends TestRouterDeploy<
   HelloWorld,
-  HelloWorldConfig
+  HelloWorldTestConfig
 > {
   async deployInstance(
     domain: types.Domain,


### PR DESCRIPTION
We had 3 different types we called HelloWorldConfig. Some of these config types won't have to be specified explicitly in the future (+ the TestRouterDeploy type will be superflous), but for now, they shouldn't share the same name